### PR TITLE
Adjust Graphiti memory filter default source types

### DIFF
--- a/functions/filter/graphiti_memory.py
+++ b/functions/filter/graphiti_memory.py
@@ -352,7 +352,7 @@ class Filter:
             description="Merge RAG retrieved context (e.g., file attachments, knowledge base hits) into the user message before saving to memory.",
         )
         allowed_rag_source_types: str | None = Field(
-            default="file",
+            default="file,text",
             description="Comma-separated list of retrieval source types to merge (e.g., 'file, web_search'). Leave blank to disable merging.",
         )
         


### PR DESCRIPTION
## Summary
- update the Graphiti memory filter default `allowed_rag_source_types` to accept both file and text inputs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690b2d8d0d8c8333bb5b1db8ee4e6d1b